### PR TITLE
Add migrations for models that were missing them

### DIFF
--- a/ecwsp/admissions/migrations/0006_auto_20150204_0811.py
+++ b/ecwsp/admissions/migrations/0006_auto_20150204_0811.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('admissions', '0005_auto_20150118_1315'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='applicantstandardtestresult',
+            name='date',
+            field=models.DateField(default=datetime.date(2015, 2, 4), validators=[django.core.validators.MinValueValidator(datetime.date(1970, 1, 1))]),
+            preserve_default=True,
+        ),
+    ]

--- a/ecwsp/grades/migrations/0004_auto_20150204_0811.py
+++ b/ecwsp/grades/migrations/0004_auto_20150204_0811.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('grades', '0003_grade_enrollment'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='grade',
+            name='letter_grade',
+            field=models.CharField(blank=True, max_length=10, null=True, help_text=b'Will override grade.', choices=[(b'I', b'Incomplete'), (b'P', b'Pass'), (b'F', b'Fail'), (b'A', b'A'), (b'B', b'B'), (b'C', b'C'), (b'D', b'D'), (b'HP', b'High Pass'), (b'LP', b'Low Pass'), (b'M', b'Missing')]),
+            preserve_default=True,
+        ),
+    ]

--- a/ecwsp/standard_test/migrations/0006_auto_20150204_0811.py
+++ b/ecwsp/standard_test/migrations/0006_auto_20150204_0811.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('standard_test', '0005_auto_20150102_1238'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='standardtestresult',
+            name='date',
+            field=models.DateField(default=datetime.date(2015, 2, 4), validators=[django.core.validators.MinValueValidator(datetime.date(1970, 1, 1))]),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
I found that there were some models that had changes that were not reflected in migrations.

You can test this yourself by running (on old code):
```
fig rm db
fig run web python manage.py migrate
fig run web python manage.py migrate
```
and it will tell you that
```
  Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```


Migrations all work fine on latest production dump of data, but didn't do any integration testing to see if they break anything.
