### PR TITLE
Disable a few signals on loaddata

### DIFF
--- a/ecwsp/admissions/models.py
+++ b/ecwsp/admissions/models.py
@@ -11,6 +11,8 @@ from django.core.mail import EmailMultiAlternatives
 from django.template import Context
 from django.template.loader import render_to_string
 
+from ecwsp.sis.helper_functions import disable_for_loaddata
+
 from jsonfield import JSONField
 import datetime
 
@@ -298,6 +300,8 @@ def cache_applicant_m2m(sender, instance, action, reverse, model, pk_set, **kwar
 
 m2m_changed.connect(cache_applicant_m2m, sender=Applicant.parent_guardians.through)
 
+
+@disable_for_loaddata
 def email_alert_for_submitted_applicant(sender, instance, created, **kwargs):
     """send email alert on applicant creation"""
     if created and config.APPLICANT_EMAIL_ALERT:

--- a/ecwsp/sis/helper_functions.py
+++ b/ecwsp/sis/helper_functions.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.db.models import AutoField
 from django.db import models, connection
 from django.core.exceptions import PermissionDenied
@@ -129,3 +131,18 @@ class CharNullField(models.CharField):
             return None
        else:
             return super(CharNullField, self).get_db_prep_value(value, *args, **kwargs)
+
+
+def disable_for_loaddata(signal_handler):
+    """
+    Decorator that turns off signal handlers when loading fixture data.
+
+    from http://stackoverflow.com/a/15625121/907060
+    """
+
+    @wraps(signal_handler)
+    def wrapper(*args, **kwargs):
+        if kwargs['raw']:
+            return
+        signal_handler(*args, **kwargs)
+    return wrapper

--- a/ecwsp/sis/models.py
+++ b/ecwsp/sis/models.py
@@ -18,8 +18,7 @@ import sys
 from ckeditor.fields import RichTextField
 from django_cached_field import CachedDecimalField
 from decimal import Decimal
-from ecwsp.sis.helper_functions import round_as_decimal
-
+from ecwsp.sis.helper_functions import round_as_decimal, disable_for_loaddata
 logger = logging.getLogger(__name__)
 
 
@@ -609,6 +608,9 @@ class Student(User, CustomFieldModel):
             cursor.execute("insert into work_study_studentworker (student_ptr_id) values (" + str(self.id) + ");")
         except:
             return
+
+
+@disable_for_loaddata
 def after_student_m2m(sender, instance, action, reverse, model, pk_set, **kwargs):
     if hasattr(instance, 'emergency_contacts'): # Apparently instance might be whatever the fuck it wants to be, not just student.
         if not instance.emergency_contacts.filter(primary_contact=True).count():


### PR DESCRIPTION
When I am importing things through loaddata, these two methods usually fail. Seems safe to disable them for the initial load in.