### PR TITLE
change permissions to DjangoModelPermissions

### DIFF
--- a/api/schedule/views.py
+++ b/api/schedule/views.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAdminUser
 from rest_framework import filters
 from ecwsp.schedule.models import Course, CourseSection
 from api.schedule.serializers import CourseSerializer, SectionSerializer
@@ -9,7 +8,6 @@ class CourseViewSet(viewsets.ModelViewSet):
     """
     an API endpoint for the Course model
     """
-    permission_classes = (IsAdminUser,)
     queryset = Course.objects.prefetch_related(
         'sections', 'sections__periods', 'sections__teachers',
         'sections__enrollments', 'sections__cohorts',
@@ -22,7 +20,6 @@ class SectionViewSet(viewsets.ModelViewSet):
     """
     an API endpoint for the CourseSection model
     """
-    permission_classes = (IsAdminUser,)
     queryset = CourseSection.objects.all()
     serializer_class = SectionSerializer
     filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)

--- a/django_sis/settings.py
+++ b/django_sis/settings.py
@@ -588,6 +588,7 @@ REST_FRAMEWORK = {
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'PAGINATE_BY_PARAM': 'page_size',
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.DjangoModelPermissions',),
 }
 
 MIGRATIONS_DISABLED = False
@@ -603,7 +604,7 @@ if 'TRAVIS' in os.environ:
         }
     }
 elif 'test' in sys.argv:
-    # Don't take fucking years to run a test
+    # Don't take years to run a test
     class DisableMigrations(object):
         def __contains__(self, item):
             return True

--- a/ecwsp/benchmarks/api_views.py
+++ b/ecwsp/benchmarks/api_views.py
@@ -1,10 +1,8 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAdminUser
 from .serializers import BenchmarkSerializer
 from .models import Benchmark
 
 
 class BenchmarkViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminUser,)
     serializer_class = BenchmarkSerializer
     queryset = Benchmark.objects.all()

--- a/ecwsp/gradebook/api_views.py
+++ b/ecwsp/gradebook/api_views.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAdminUser
 from .serializers import (
     AssignmentSerializer, MarkSerializer, AssignmentCategorySerializer, 
     AssignmentTypeSerializer)
@@ -7,24 +6,20 @@ from .models import Assignment, Mark, AssignmentCategory, AssignmentType
 
 
 class AssignmentViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminUser,)
     serializer_class = AssignmentSerializer
     queryset = Assignment.objects.all()
 
 
 class MarkViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminUser,)
     serializer_class = MarkSerializer
     queryset = Mark.objects.all()
 
 
 class AssignmentCategoryViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminUser,)
     serializer_class = AssignmentCategorySerializer
     queryset = AssignmentCategory.objects.all()
 
 
 class AssignmentTypeViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminUser,)
     serializer_class = AssignmentTypeSerializer
     queryset = AssignmentType.objects.all()


### PR DESCRIPTION
Removed permission classes from three API view files (grades, gradebook, benchmarks).

Added a thing in settings to default to DjangoModelPermissions.

And that's it! Seems to work okay.